### PR TITLE
add sardine.reviews

### DIFF
--- a/creators.js
+++ b/creators.js
@@ -8,7 +8,8 @@ var urlArray = [
     "https://cubecube.org/",
     "https://twitter.com/andrei_pestee",
     "https://3dprintguides.com/",
-    "https://limbo.center/"
+    "https://limbo.center/",
+    "https://sardine.reviews/"
 ];
 
 function randomUrl() {

--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
     <li><div class="tooltip"><a href="https://twitter.com/andrei_pestee">Andrei Peste:</a> <span class="tooltiptext">Unique, morbid artwork</span></div></li>
     <li><div class="tooltip"><a href="https://3dprintguides.com/">3D Print Guides:</a> <span class="tooltiptext">3D printing code and tutorials</span></div></li>
     <li><div class="tooltip"><a href="https://limbo.center/">Limbo Central:</a> <span class="tooltiptext">Music, Computers, Internet</span></div></li>
+    <li><div class="tooltip"><a href="https://sardine.reviews/">Sardine.Reviews:</a> <span class="tooltiptext">Humorous reviews of canned fish</span></div></li>
 </ul>
 </p>
 </main>

--- a/webring.js
+++ b/webring.js
@@ -6,7 +6,8 @@ var frameArray = [
     "https://ashkankamyab.com/",
     "https://cubecube.org/",
     "https://3dprintguides.com/",
-    "https://limbo.center/"
+    "https://limbo.center/",
+    "https://sardine.reviews/"
 ];
 
 const len = frameArray.length;


### PR DESCRIPTION
This pull adds https://sardine.reviews to the webring. Below are a bunch of tangentially related comments.

I was tempted to remove the right angle bracket from Ashkan Kamyab's tooltip but left it alone for now since it's not relevant to this pull.

Note that the list of URL's in creators.js and webring.js are not the same. I think the exclusion of https://brave.cafe/ may be intentional, but probably not the exclusion of https://twitter.com/andrei_pestee. I think we should have a unified array that is referenced by both creators.js and webring.js, and then if you want to exclude certain urls from the webring you can just filter them out.

Another idea that would make additions to the webring easier is to use a simple datafile (csv probably) that lists all of the creators, their names, links, and tooltips/descriptions, and then a simple build process (Make!) that builds the requisite js and html files. The data file could actually just be a separate repo if you want to keep the pull request flow of adding creators.

Lastly, the limited length of the tooltips is problematic. I had to chop my desired tooltip down to fit, so it might be better to do away with the tooltip concept entirely and just show the description with each webring member, with wrapping (no more 2 column list,) and just impose a soft limit on description lengths by reviewing the pulls to make sure they're not too long.

Just some thoughts! Grateful you're doing this 🙏